### PR TITLE
Use dict outputs, fix tests

### DIFF
--- a/docs/examples/example.py
+++ b/docs/examples/example.py
@@ -89,7 +89,9 @@ Omega = Uinf*tsr/Rtip * 30.0/pi  # convert to RPM
 azimuth = 0.0
 
 # evaluate distributed loads
-Np, Tp = rotor.distributedAeroLoads(Uinf, Omega, pitch, azimuth)
+loads, derivs = rotor.distributedAeroLoads(Uinf, Omega, pitch, azimuth)
+Np = loads['Np']
+Tp = loads['Tp']
 
 # 4 ----------
 
@@ -117,13 +119,19 @@ plt.show()
 
 # 6 ----------
 
-P, T, Q = rotor.evaluate([Uinf], [Omega], [pitch])
+outputs, derivs = rotor.evaluate([Uinf], [Omega], [pitch])
+P = outputs['P']
+T = outputs['T']
+Q = outputs['Q']
 
-CP, CT, CQ = rotor.evaluate([Uinf], [Omega], [pitch], coefficient=True)
+outputs, derivs = rotor.evaluate([Uinf], [Omega], [pitch], coefficient=True)
+CP = outputs['CP']
+CT = outputs['CT']
+CQ = outputs['CQ']
 
-print 'CP =', CP
-print 'CT =', CT
-print 'CQ =', CQ
+print('CP =', CP)
+print('CT =', CT)
+print('CQ =', CQ)
 
 # 6 ----------
 
@@ -135,7 +143,11 @@ Omega = 10.0 * np.ones_like(tsr)
 Uinf = Omega*pi/30.0 * Rtip/tsr
 pitch = np.zeros_like(tsr)
 
-CP, CT, CQ = rotor.evaluate(Uinf, Omega, pitch, coefficient=True)
+outputs, derivs = rotor.evaluate(Uinf, Omega, pitch, coefficient=True)
+CP = outputs['CP']
+CT = outputs['CT']
+CQ = outputs['CQ']
+
 
 plt.figure()
 plt.plot(tsr, CP)

--- a/docs/examples/gradients.py
+++ b/docs/examples/gradients.py
@@ -94,8 +94,11 @@ azimuth = 0.0
 
 # 5 ----------
 
-Np, Tp, dNp, dTp \
-    = rotor.distributedAeroLoads(Uinf, Omega, pitch, azimuth)
+loads, derivs = rotor.distributedAeroLoads(Uinf, Omega, pitch, azimuth)
+Np = loads['Np']
+Tp = loads['Tp']
+dNp = derivs['dNp']
+dTp = derivs['dTp']
 
 n = len(r)
 
@@ -126,8 +129,13 @@ dNp_dpitch = dNp['dpitch']
 # 6 ----------
 
 
-P, T, Q, dP, dT, dQ \
-    = rotor.evaluate([Uinf], [Omega], [pitch])
+outputs, derivs = rotor.evaluate([Uinf], [Omega], [pitch])
+P = outputs['P']
+T = outputs['T']
+Q = outputs['Q']
+dP = derivs['dP']
+dT = derivs['dT']
+dQ = derivs['dQ']
 
 npts = len(P)
 
@@ -169,7 +177,9 @@ rotor_fd = CCBlade(r, chord, theta, af, Rhub, Rtip, B, rho, mu,
 
 r[idx] -= delta
 
-Npd, Tpd = rotor_fd.distributedAeroLoads(Uinf, Omega, pitch, azimuth)
+loads, derivs = rotor_fd.distributedAeroLoads(Uinf, Omega, pitch, azimuth)
+Npd = loads['Np']
+Tpd = loads['Tp']
 
 dNp_dr_fd = (Npd - Np) / delta
 dTp_dr_fd = (Tpd - Tp) / delta
@@ -190,7 +200,10 @@ rotor_fd = CCBlade(r, chord, theta, af, Rhub, Rtip,
 
 precone -= delta
 
-Pd, Td, Qd = rotor_fd.evaluate([Uinf], [Omega], [pitch], coefficient=False)
+outputs, derivs = rotor_fd.evaluate([Uinf], [Omega], [pitch], coefficient=False)
+Pd = outputs['P']
+Td = outputs['T']
+Qd = outputs['Q']
 
 dT_dprecone_fd = (Td - T) / delta
 dQ_dprecone_fd = (Qd - Q) / delta
@@ -213,7 +226,10 @@ rotor_fd = CCBlade(r, chord, theta, af, Rhub, Rtip,
 
 r[idx] -= delta
 
-Pd, Td, Qd = rotor_fd.evaluate([Uinf], [Omega], [pitch], coefficient=False)
+outputs, derivs = rotor_fd.evaluate([Uinf], [Omega], [pitch], coefficient=False)
+Pd = outputs['P']
+Td = outputs['T']
+Qd = outputs['Q']
 
 dT_dr_fd = (Td - T) / delta
 dQ_dr_fd = (Qd - Q) / delta

--- a/src/ccblade/ccblade.py
+++ b/src/ccblade/ccblade.py
@@ -1334,7 +1334,9 @@ if __name__ == '__main__':
     azimuth = 90
 
     # evaluate distributed loads
-    Np, Tp = aeroanalysis.distributedAeroLoads(Uinf, Omega, pitch, azimuth)
+    loads, derivs = aeroanalysis.distributedAeroLoads(Uinf, Omega, pitch, azimuth)
+    Np = loads['Np']
+    Tp = loads['Tp']
 
     # plot
     import matplotlib.pyplot as plt
@@ -1345,7 +1347,10 @@ if __name__ == '__main__':
     plt.ylabel('distributed aerodynamic loads (kN)')
     plt.legend(loc='upper left')
 
-    CP, CT, CQ = aeroanalysis.evaluate([Uinf], [Omega], [pitch], coefficient=True)
+    outputs, _ = aeroanalysis.evaluate([Uinf], [Omega], [pitch], coefficients=True)
+    CP = outputs['CP']
+    CT = outputs['CT']
+    CQ = outputs['CQ']
 
     print(CP, CT, CQ)
 
@@ -1355,7 +1360,10 @@ if __name__ == '__main__':
     Uinf = Omega*pi/30.0 * Rtip/tsr
     pitch = np.zeros_like(tsr)
 
-    CP, CT, CQ = aeroanalysis.evaluate(Uinf, Omega, pitch, coefficient=True)
+    outputs, _ = aeroanalysis.evaluate(Uinf, Omega, pitch, coefficients=True)
+    CP = outputs['CP']
+    CT = outputs['CT']
+    CQ = outputs['CQ']
 
     plt.figure()
     plt.plot(tsr, CP, 'k')

--- a/src/ccblade/ccblade.py
+++ b/src/ccblade/ccblade.py
@@ -866,12 +866,8 @@ class CCBlade(object):
                 dNp_dVy[i] = DNp_Dx[3]
                 dTp_dVy[i] = DTp_Dx[3]
 
-
-        if not self.derivatives:
-            derivs = {}
-
-        else:
-
+        derivs = {}
+        if self.derivatives:
             # chain rule
             dNp_dw = dNp_dVx*dVx_dw + dNp_dVy*dVy_dw
             dTp_dw = dTp_dVx*dVx_dw + dTp_dVy*dVy_dw
@@ -942,7 +938,7 @@ class CCBlade(object):
             dTp['dpitch'] = dTp_dX[13, :].reshape(n, 1)
 
             derivs['dNp'] = dNp
-            derivs['dTp']  = dTp
+            derivs['dTp'] = dTp
 
         loads = {'a': a, 'ap': ap, 'Np': Np, 'Tp': Tp,
                  'alpha': alpha, 'Cl': cl, 'Cd': cd, 'Cn': cn, 'Ct': ct,
@@ -1113,18 +1109,30 @@ class CCBlade(object):
             # pack derivatives into dictionary
             dT, dQ, dP = self.__thrustTorqueDictionary(dT_ds, dQ_ds, dP_ds, dT_dv, dQ_dv, dP_dv, npts)
         
-        
-        if coefficients:
-            if self.derivatives:
-                return P, T, Q, M, dP, dT, dQ, CP, CT, CQ, CM, dCP, dCT, dCQ
-            else:
-                return P, T, Q, M, CP, CT, CQ, CM
-        else:
-            if self.derivatives:
-                return P, T, Q, M, dP, dT, dQ
-            else:
-                return P, T, Q, M
 
+
+        outputs = {}
+        derivs = {}
+        if coefficients:
+            outputs['CP'] = CP
+            outputs['CT'] = CT
+            outputs['CQ'] = CQ
+            outputs['CM'] = CM
+            if self.derivatives:
+                derivs['dCP'] = dCP
+                derivs['dCT'] = dCT
+                derivs['dCQ'] = dCQ
+        else:
+            outputs['P'] = P
+            outputs['T'] = T
+            outputs['Q'] = Q
+            outputs['M'] = M
+            if self.derivatives:
+                derivs['dP'] = dP
+                derivs['dT'] = dT
+                derivs['dQ'] = dQ
+
+        return outputs, derivs
 
 
 

--- a/test/test_ccblade.py
+++ b/test/test_ccblade.py
@@ -103,7 +103,8 @@ class TestNREL5MW(unittest.TestCase):
         tilt = 5*math.pi/180.0
         Tref -= m_rotor*g*math.sin(tilt)  # remove weight of rotor that is included in reported results
 
-        P, T, Q, M = self.rotor.evaluate(Uinf, Omega, pitch)
+        outputs, derivs = self.rotor.evaluate(Uinf, Omega, pitch)
+        P, T, Q, M = [outputs[key] for key in ('P', 'T', 'Q', 'M')]
 
         # import matplotlib.pyplot as plt
         # plt.plot(Uinf, P/1e6)

--- a/test/test_gradients.py
+++ b/test/test_gradients.py
@@ -83,14 +83,19 @@ class TestGradients(unittest.TestCase):
         self.azimuth = 90
 
 
-        self.Np, self.Tp, self.dNp, self.dTp \
-            = self.rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, derivs = self.rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        self.Np = loads['Np']
+        self.Tp = loads['Tp']
+        self.dNp = derivs['dNp']
+        self.dTp = derivs['dTp']
 
-        self.P, self.T, self.Q, self.dP, self.dT, self.dQ \
-            = self.rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=False)
+        outputs, derivs = self.rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=False)
+        self.P, self.T, self.Q, self.M = [outputs[k] for k in ('P', 'T', 'Q', 'M')]
+        self.dP, self.dT, self.dQ = [derivs[k] for k in ('dP', 'dT', 'dQ')]
 
-        self.CP, self.CT, self.CQ, self.dCP, self.dCT, self.dCQ \
-            = self.rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=True)
+        outputs, derivs = self.rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=True)
+        self.CP, self.CT, self.CQ, self.CM = [outputs[k] for k in ('CP', 'CT', 'CQ', 'CM')]
+        self.dCP, self.dCT, self.dCQ     = [derivs[k] for k in ('dCP', 'dCT', 'dCQ')]
 
         self.rotor.derivatives = False
         self.n = len(self.r)
@@ -113,7 +118,9 @@ class TestGradients(unittest.TestCase):
                 self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
                 self.hubHt, self.nSector, derivatives=False)
 
-            Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+            loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+            Npd = loads['Np']
+            Tpd = loads['Tp']
 
             dNp_dr_fd[:, i] = (Npd - self.Np) / delta
             dTp_dr_fd[:, i] = (Tpd - self.Tp) / delta
@@ -141,7 +148,10 @@ class TestGradients(unittest.TestCase):
                 self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
                 self.hubHt, self.nSector, derivatives=False)
 
-            Pd, Td, Qd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=False)
+            outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=False)
+            Pd = outputs['P']
+            Td = outputs['T']
+            Qd = outputs['Q']
 
             dT_dr_fd[:, i] = (Td - self.T) / delta
             dQ_dr_fd[:, i] = (Qd - self.Q) / delta
@@ -170,7 +180,10 @@ class TestGradients(unittest.TestCase):
                 self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
                 self.hubHt, self.nSector, derivatives=False)
 
-            CPd, CTd, CQd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=True)
+            outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=True)
+            CPd = outputs['CP']
+            CTd = outputs['CT']
+            CQd = outputs['CQ']
 
             dCT_dr_fd[:, i] = (CTd - self.CT) / delta
             dCQ_dr_fd[:, i] = (CQd - self.CQ) / delta
@@ -198,7 +211,9 @@ class TestGradients(unittest.TestCase):
                 self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
                 self.hubHt, self.nSector, derivatives=False)
 
-            Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+            loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+            Npd = loads['Np']
+            Tpd = loads['Tp']
 
             dNp_dchord_fd[:, i] = (Npd - self.Np) / delta
             dTp_dchord_fd[:, i] = (Tpd - self.Tp) / delta
@@ -227,7 +242,10 @@ class TestGradients(unittest.TestCase):
                 self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
                 self.hubHt, self.nSector, derivatives=False)
 
-            Pd, Td, Qd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=False)
+            outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=False)
+            Pd = outputs['P']
+            Td = outputs['T']
+            Qd = outputs['Q']
 
             dT_dchord_fd[:, i] = (Td - self.T) / delta
             dQ_dchord_fd[:, i] = (Qd - self.Q) / delta
@@ -256,7 +274,10 @@ class TestGradients(unittest.TestCase):
                 self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
                 self.hubHt, self.nSector, derivatives=False)
 
-            CPd, CTd, CQd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=True)
+            outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=True)
+            CPd = outputs['CP']
+            CTd = outputs['CT']
+            CQd = outputs['CQ']
 
             dCT_dchord_fd[:, i] = (CTd - self.CT) / delta
             dCQ_dchord_fd[:, i] = (CQd - self.CQ) / delta
@@ -285,7 +306,9 @@ class TestGradients(unittest.TestCase):
                 self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
                 self.hubHt, self.nSector, derivatives=False)
 
-            Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+            loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+            Npd = loads['Np']
+            Tpd = loads['Tp']
 
             dNp_dtheta_fd[:, i] = (Npd - self.Np) / delta
             dTp_dtheta_fd[:, i] = (Tpd - self.Tp) / delta
@@ -313,7 +336,10 @@ class TestGradients(unittest.TestCase):
                 self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
                 self.hubHt, self.nSector, derivatives=False)
 
-            Pd, Td, Qd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=False)
+            outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=False)
+            Pd = outputs['P']
+            Td = outputs['T']
+            Qd = outputs['Q']
 
             dT_dtheta_fd[:, i] = (Td - self.T) / delta
             dQ_dtheta_fd[:, i] = (Qd - self.Q) / delta
@@ -343,7 +369,10 @@ class TestGradients(unittest.TestCase):
                 self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
                 self.hubHt, self.nSector, derivatives=False)
 
-            CPd, CTd, CQd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=True)
+            outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=True)
+            CPd = outputs['CP']
+            CTd = outputs['CT']
+            CQd = outputs['CQ']
 
             dCT_dtheta_fd[:, i] = (CTd - self.CT) / delta
             dCQ_dtheta_fd[:, i] = (CQd - self.CQ) / delta
@@ -371,7 +400,9 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False)
 
-        Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Npd = loads['Np']
+        Tpd = loads['Tp']
 
         dNp_dRhub_fd[:, 0] = (Npd - self.Np) / delta
         dTp_dRhub_fd[:, 0] = (Tpd - self.Tp) / delta
@@ -398,7 +429,10 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False)
 
-        Pd, Td, Qd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=False)
+        outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=False)
+        Pd = outputs['P']
+        Td = outputs['T']
+        Qd = outputs['Q']
 
         dT_dRhub_fd[:, 0] = (Td - self.T) / delta
         dQ_dRhub_fd[:, 0] = (Qd - self.Q) / delta
@@ -428,7 +462,10 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False)
 
-        CPd, CTd, CQd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=True)
+        outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=True)
+        CPd = outputs['CP']
+        CTd = outputs['CT']
+        CQd = outputs['CQ']
 
         dCT_dRhub_fd[:, 0] = (CTd - self.CT) / delta
         dCQ_dRhub_fd[:, 0] = (CQd - self.CQ) / delta
@@ -456,7 +493,10 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False)
 
-        Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Npd = loads['Np']
+        Tpd = loads['Tp']
+
         dNp_dRtip_fd[:, 0] = (Npd - self.Np) / delta
         dTp_dRtip_fd[:, 0] = (Tpd - self.Tp) / delta
 
@@ -482,7 +522,10 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False)
 
-        Pd, Td, Qd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=False)
+        outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=False)
+        Pd = outputs['P']
+        Td = outputs['T']
+        Qd = outputs['Q']
 
         dT_dRtip_fd[:, 0] = (Td - self.T) / delta
         dQ_dRtip_fd[:, 0] = (Qd - self.Q) / delta
@@ -511,7 +554,10 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False)
 
-        CPd, CTd, CQd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=True)
+        outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=True)
+        CPd = outputs['CP']
+        CTd = outputs['CT']
+        CQd = outputs['CQ']
 
         dCT_dRtip_fd[:, 0] = (CTd - self.CT) / delta
         dCQ_dRtip_fd[:, 0] = (CQd - self.CQ) / delta
@@ -538,7 +584,9 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False)
 
-        Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Npd = loads['Np']
+        Tpd = loads['Tp']
 
         dNp_dprecone_fd[:, 0] = (Npd - self.Np) / delta
         dTp_dprecone_fd[:, 0] = (Tpd - self.Tp) / delta
@@ -566,7 +614,10 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False)
 
-        Pd, Td, Qd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=False)
+        outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=False)
+        Pd = outputs['P']
+        Td = outputs['T']
+        Qd = outputs['Q']
 
         dT_dprecone_fd[:, 0] = (Td - self.T) / delta
         dQ_dprecone_fd[:, 0] = (Qd - self.Q) / delta
@@ -595,7 +646,10 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False)
 
-        CPd, CTd, CQd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=True)
+        outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=True)
+        CPd = outputs['CP']
+        CTd = outputs['CT']
+        CQd = outputs['CQ']
 
         dCT_dprecone_fd[:, 0] = (CTd - self.CT) / delta
         dCQ_dprecone_fd[:, 0] = (CQd - self.CQ) / delta
@@ -622,7 +676,9 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, self.precone, tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False)
 
-        Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Npd = loads['Np']
+        Tpd = loads['Tp']
 
         dNp_dtilt_fd[:, 0] = (Npd - self.Np) / delta
         dTp_dtilt_fd[:, 0] = (Tpd - self.Tp) / delta
@@ -649,7 +705,10 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, self.precone, tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False)
 
-        Pd, Td, Qd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=False)
+        outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=False)
+        Pd = outputs['P']
+        Td = outputs['T']
+        Qd = outputs['Q']
 
         dT_dtilt_fd[:, 0] = (Td - self.T) / delta
         dQ_dtilt_fd[:, 0] = (Qd - self.Q) / delta
@@ -678,7 +737,10 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, self.precone, tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False)
 
-        CPd, CTd, CQd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=True)
+        outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=True)
+        CPd = outputs['CP']
+        CTd = outputs['CT']
+        CQd = outputs['CQ']
 
         dCT_dtilt_fd[:, 0] = (CTd - self.CT) / delta
         dCQ_dtilt_fd[:, 0] = (CQd - self.CQ) / delta
@@ -705,7 +767,9 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
             hubht, self.nSector, derivatives=False)
 
-        Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Npd = loads['Np']
+        Tpd = loads['Tp']
 
         dNp_dhubht_fd[:, 0] = (Npd - self.Np) / delta
         dTp_dhubht_fd[:, 0] = (Tpd - self.Tp) / delta
@@ -732,7 +796,10 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
             hubht, self.nSector, derivatives=False)
 
-        Pd, Td, Qd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=False)
+        outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=False)
+        Pd = outputs['P']
+        Td = outputs['T']
+        Qd = outputs['Q']
 
         dT_dhubht_fd[:, 0] = (Td - self.T) / delta
         dQ_dhubht_fd[:, 0] = (Qd - self.Q) / delta
@@ -762,7 +829,10 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
             hubht, self.nSector, derivatives=False)
 
-        CPd, CTd, CQd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=True)
+        outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=True)
+        CPd = outputs['CP']
+        CTd = outputs['CT']
+        CQd = outputs['CQ']
 
         dCT_dhubht_fd[:, 0] = (CTd - self.CT) / delta
         dCQ_dhubht_fd[:, 0] = (CQd - self.CQ) / delta
@@ -790,7 +860,9 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, self.precone, self.tilt, yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False)
 
-        Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Npd = loads['Np']
+        Tpd = loads['Tp']
 
         dNp_dyaw_fd[:, 0] = (Npd - self.Np) / delta
         dTp_dyaw_fd[:, 0] = (Tpd - self.Tp) / delta
@@ -817,7 +889,10 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, self.precone, self.tilt, yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False)
 
-        Pd, Td, Qd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=False)
+        outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=False)
+        Pd = outputs['P']
+        Td = outputs['T']
+        Qd = outputs['Q']
 
         dT_dyaw_fd[:, 0] = (Td - self.T) / delta
         dQ_dyaw_fd[:, 0] = (Qd - self.Q) / delta
@@ -847,7 +922,10 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, self.precone, self.tilt, yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False)
 
-        CPd, CTd, CQd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=True)
+        outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=True)
+        CPd = outputs['CP']
+        CTd = outputs['CT']
+        CQd = outputs['CQ']
 
         dCT_dyaw_fd[:, 0] = (CTd - self.CT) / delta
         dCQ_dyaw_fd[:, 0] = (CQd - self.CQ) / delta
@@ -871,7 +949,9 @@ class TestGradients(unittest.TestCase):
         delta = 1e-6*azimuth
         azimuth += delta
 
-        Npd, Tpd = self.rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, azimuth)
+        outputs, _ = self.rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, azimuth)
+        Npd = outputs['Np']
+        Tpd = outputs['Tp']
 
         dNp_dazimuth_fd[:, 0] = (Npd - self.Np) / delta
         dTp_dazimuth_fd[:, 0] = (Tpd - self.Tp) / delta
@@ -892,7 +972,9 @@ class TestGradients(unittest.TestCase):
         delta = 1e-6*Uinf
         Uinf += delta
 
-        Npd, Tpd = self.rotor.distributedAeroLoads(Uinf, self.Omega, self.pitch, self.azimuth)
+        outputs, _ = self.rotor.distributedAeroLoads(Uinf, self.Omega, self.pitch, self.azimuth)
+        Npd = outputs['Np']
+        Tpd = outputs['Tp']
 
         dNp_dUinf_fd[:, 0] = (Npd - self.Np) / delta
         dTp_dUinf_fd[:, 0] = (Tpd - self.Tp) / delta
@@ -915,7 +997,10 @@ class TestGradients(unittest.TestCase):
         delta = 1e-6*Uinf
         Uinf += delta
 
-        Pd, Td, Qd = self.rotor.evaluate([Uinf], [self.Omega], [self.pitch], coefficient=False)
+        outputs, _ = self.rotor.evaluate([Uinf], [self.Omega], [self.pitch], coefficients=False)
+        Pd = outputs['P']
+        Td = outputs['T']
+        Qd = outputs['Q']
 
         dT_dUinf_fd[:, 0] = (Td - self.T) / delta
         dQ_dUinf_fd[:, 0] = (Qd - self.Q) / delta
@@ -941,7 +1026,10 @@ class TestGradients(unittest.TestCase):
         delta = 1e-6*Uinf
         Uinf += delta
 
-        CPd, CTd, CQd = self.rotor.evaluate([Uinf], [self.Omega], [self.pitch], coefficient=True)
+        outputs, _ = self.rotor.evaluate([Uinf], [self.Omega], [self.pitch], coefficients=True)
+        CPd = outputs['CP']
+        CTd = outputs['CT']
+        CQd = outputs['CQ']
 
         dCT_dUinf_fd[:, 0] = (CTd - self.CT) / delta
         dCQ_dUinf_fd[:, 0] = (CQd - self.CQ) / delta
@@ -964,7 +1052,9 @@ class TestGradients(unittest.TestCase):
         delta = 1e-6*Omega
         Omega += delta
 
-        Npd, Tpd = self.rotor.distributedAeroLoads(self.Uinf, Omega, self.pitch, self.azimuth)
+        loads, _ = self.rotor.distributedAeroLoads(self.Uinf, Omega, self.pitch, self.azimuth)
+        Npd = loads['Np']
+        Tpd = loads['Tp']
 
         dNp_dOmega_fd[:, 0] = (Npd - self.Np) / delta
         dTp_dOmega_fd[:, 0] = (Tpd - self.Tp) / delta
@@ -987,7 +1077,10 @@ class TestGradients(unittest.TestCase):
         delta = 1e-6*Omega
         Omega += delta
 
-        Pd, Td, Qd = self.rotor.evaluate([self.Uinf], [Omega], [self.pitch], coefficient=False)
+        outputs, _ = self.rotor.evaluate([self.Uinf], [Omega], [self.pitch], coefficients=False)
+        Pd = outputs['P']
+        Td = outputs['T']
+        Qd = outputs['Q']
 
         dT_dOmega_fd[:, 0] = (Td - self.T) / delta
         dQ_dOmega_fd[:, 0] = (Qd - self.Q) / delta
@@ -1013,7 +1106,10 @@ class TestGradients(unittest.TestCase):
         delta = 1e-6*Omega
         Omega += delta
 
-        CPd, CTd, CQd = self.rotor.evaluate([self.Uinf], [Omega], [self.pitch], coefficient=True)
+        outputs, _ = self.rotor.evaluate([self.Uinf], [Omega], [self.pitch], coefficients=True)
+        CPd = outputs['CP']
+        CTd = outputs['CT']
+        CQd = outputs['CQ']
 
         dCT_dOmega_fd[:, 0] = (CTd - self.CT) / delta
         dCQ_dOmega_fd[:, 0] = (CQd - self.CQ) / delta
@@ -1037,7 +1133,9 @@ class TestGradients(unittest.TestCase):
         delta = 1e-6
         pitch += delta
 
-        Npd, Tpd = self.rotor.distributedAeroLoads(self.Uinf, self.Omega, pitch, self.azimuth)
+        loads, _ = self.rotor.distributedAeroLoads(self.Uinf, self.Omega, pitch, self.azimuth)
+        Npd = loads['Np']
+        Tpd = loads['Tp']
 
         dNp_dpitch_fd[:, 0] = (Npd - self.Np) / delta
         dTp_dpitch_fd[:, 0] = (Tpd - self.Tp) / delta
@@ -1060,7 +1158,10 @@ class TestGradients(unittest.TestCase):
         delta = 1e-6
         pitch += delta
 
-        Pd, Td, Qd = self.rotor.evaluate([self.Uinf], [self.Omega], [pitch], coefficient=False)
+        outputs, _ = self.rotor.evaluate([self.Uinf], [self.Omega], [pitch], coefficients=False)
+        Pd = outputs['P']
+        Td = outputs['T']
+        Qd = outputs['Q']
 
         dT_dpitch_fd[:, 0] = (Td - self.T) / delta
         dQ_dpitch_fd[:, 0] = (Qd - self.Q) / delta
@@ -1086,7 +1187,10 @@ class TestGradients(unittest.TestCase):
         delta = 1e-6
         pitch += delta
 
-        CPd, CTd, CQd = self.rotor.evaluate([self.Uinf], [self.Omega], [pitch], coefficient=True)
+        outputs, _ = self.rotor.evaluate([self.Uinf], [self.Omega], [pitch], coefficients=True)
+        CPd = outputs['CP']
+        CTd = outputs['CT']
+        CQd = outputs['CQ']
 
         dCT_dpitch_fd[:, 0] = (CTd - self.CT) / delta
         dCQ_dpitch_fd[:, 0] = (CQd - self.CQ) / delta
@@ -1107,8 +1211,11 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=True, precurve=precurve, precurveTip=precurveTip)
 
-        Np, Tp, dNp, dTp \
-            = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, derivs = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Np = loads['Np']
+        Tp = loads['Tp']
+        dNp = derivs['dNp']
+        dTp = derivs['dTp']
 
         dNp_dprecurve = dNp['dprecurve']
         dTp_dprecurve = dTp['dprecurve']
@@ -1125,7 +1232,9 @@ class TestGradients(unittest.TestCase):
                 self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
                 self.hubHt, self.nSector, derivatives=False, precurve=pc, precurveTip=precurveTip)
 
-            Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+            loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+            Npd = loads['Np']
+            Tpd = loads['Tp']
 
             dNp_dprecurve_fd[:, i] = (Npd - Np) / delta
             dTp_dprecurve_fd[:, i] = (Tpd - Tp) / delta
@@ -1144,8 +1253,13 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=True, precurve=precurve, precurveTip=precurveTip)
 
-        P, T, Q, dP, dT, dQ \
-            = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=False)
+        outputs, derivs = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=False)
+        P = outputs['P']
+        T = outputs['T']
+        Q = outputs['Q']
+        dP = derivs['dP']
+        dT = derivs['dT']
+        dQ = derivs['dQ']
 
         dT_dprecurve = dT['dprecurve']
         dQ_dprecurve = dQ['dprecurve']
@@ -1163,7 +1277,10 @@ class TestGradients(unittest.TestCase):
                 self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
                 self.hubHt, self.nSector, derivatives=False, precurve=pc, precurveTip=precurveTip)
 
-            Pd, Td, Qd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=False)
+            outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=False)
+            Pd = outputs['P']
+            Td = outputs['T']
+            Qd = outputs['Q']
 
             dT_dprecurve_fd[:, i] = (Td - T) / delta
             dQ_dprecurve_fd[:, i] = (Qd - Q) / delta
@@ -1183,8 +1300,13 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=True, precurve=precurve, precurveTip=precurveTip)
 
-        CP, CT, CQ, dCP, dCT, dCQ \
-            = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=True)
+        outputs, derivs = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=True)
+        CP = outputs['CP']
+        CT = outputs['CT']
+        CQ = outputs['CQ']
+        dCP = derivs['dCP']
+        dCT = derivs['dCT']
+        dCQ = derivs['dCQ']
 
         dCT_dprecurve = dCT['dprecurve']
         dCQ_dprecurve = dCQ['dprecurve']
@@ -1203,7 +1325,10 @@ class TestGradients(unittest.TestCase):
                 self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
                 self.hubHt, self.nSector, derivatives=False, precurve=pc, precurveTip=precurveTip)
 
-            CPd, CTd, CQd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=True)
+            outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=True)
+            CPd = outputs['CP']
+            CTd = outputs['CT']
+            CQd = outputs['CQ']
 
             dCT_dprecurve_fd[:, i] = (CTd - CT) / delta
             dCQ_dprecurve_fd[:, i] = (CQd - CQ) / delta
@@ -1223,8 +1348,11 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=True, presweep=presweep, presweepTip=presweepTip)
 
-        Np, Tp, dNp, dTp \
-            = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, derivs = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Np = loads['Np']
+        Tp = loads['Tp']
+        dNp = derivs['dNp']
+        dTp = derivs['dTp']
 
         dNp_dpresweep = dNp['dpresweep']
         dTp_dpresweep = dTp['dpresweep']
@@ -1241,7 +1369,9 @@ class TestGradients(unittest.TestCase):
                 self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
                 self.hubHt, self.nSector, derivatives=False, presweep=ps, presweepTip=presweepTip)
 
-            Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+            loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+            Npd = loads['Np']
+            Tpd = loads['Tp']
 
             dNp_dpresweep_fd[:, i] = (Npd - Np) / delta
             dTp_dpresweep_fd[:, i] = (Tpd - Tp) / delta
@@ -1259,8 +1389,13 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=True, presweep=presweep, presweepTip=presweepTip)
 
-        P, T, Q, dP, dT, dQ \
-            = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=False)
+        outputs, derivs = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=False)
+        P = outputs['P']
+        T = outputs['T']
+        Q = outputs['Q']
+        dP = derivs['dP']
+        dT = derivs['dT']
+        dQ = derivs['dQ']
 
         dT_dpresweep = dT['dpresweep']
         dQ_dpresweep = dQ['dpresweep']
@@ -1279,7 +1414,10 @@ class TestGradients(unittest.TestCase):
                 self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
                 self.hubHt, self.nSector, derivatives=False, presweep=ps, presweepTip=presweepTip)
 
-            Pd, Td, Qd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=False)
+            outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=False)
+            Pd = outputs['P']
+            Td = outputs['T']
+            Qd = outputs['Q']
 
             dT_dpresweep_fd[:, i] = (Td - T) / delta
             dQ_dpresweep_fd[:, i] = (Qd - Q) / delta
@@ -1302,8 +1440,13 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=True, presweep=presweep, presweepTip=presweepTip)
 
-        CP, CT, CQ, dCP, dCT, dCQ \
-            = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=True)
+        outputs, derivs = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=True)
+        CP = outputs['CP']
+        CT = outputs['CT']
+        CQ = outputs['CQ']
+        dCP = derivs['dCP']
+        dCT = derivs['dCT']
+        dCQ = derivs['dCQ']
 
         dCT_dpresweep = dCT['dpresweep']
         dCQ_dpresweep = dCQ['dpresweep']
@@ -1321,7 +1464,10 @@ class TestGradients(unittest.TestCase):
                 self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
                 self.hubHt, self.nSector, derivatives=False, presweep=ps, presweepTip=presweepTip)
 
-            CPd, CTd, CQd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=True)
+            outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=True)
+            CPd = outputs['CP']
+            CTd = outputs['CT']
+            CQd = outputs['CQ']
 
             dCT_dpresweep_fd[:, i] = (CTd - CT) / delta
             dCQ_dpresweep_fd[:, i] = (CQd - CQ) / delta
@@ -1343,8 +1489,9 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=True, precurve=precurve, precurveTip=precurveTip)
 
-        Np, Tp, dNp, dTp \
-            = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Np = loads['Np']
+        Tp = loads['Tp']
 
         dNp_dprecurveTip_fd = np.zeros((self.n, 1))
         dTp_dprecurveTip_fd = np.zeros((self.n, 1))
@@ -1357,7 +1504,9 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False, precurve=precurve, precurveTip=pct)
 
-        Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Npd = loads['Np']
+        Tpd = loads['Tp']
         dNp_dprecurveTip_fd[:, 0] = (Npd - Np) / delta
         dTp_dprecurveTip_fd[:, 0] = (Tpd - Tp) / delta
 
@@ -1374,8 +1523,13 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=True, precurve=precurve, precurveTip=precurveTip)
 
-        P, T, Q, dP, dT, dQ \
-            = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=False)
+        outputs, derivs = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=False)
+        P = outputs['P']
+        T = outputs['T']
+        Q = outputs['Q']
+        dP = derivs['dP']
+        dT = derivs['dT']
+        dQ = derivs['dQ']
 
         dT_dprecurveTip = dT['dprecurveTip']
         dQ_dprecurveTip = dQ['dprecurveTip']
@@ -1393,7 +1547,10 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False, precurve=precurve, precurveTip=pct)
 
-        Pd, Td, Qd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=False)
+        outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=False)
+        Pd = outputs['P']
+        Td = outputs['T']
+        Qd = outputs['Q']
 
         dT_dprecurveTip_fd[:, 0] = (Td - T) / delta
         dQ_dprecurveTip_fd[:, 0] = (Qd - Q) / delta
@@ -1414,8 +1571,13 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=True, precurve=precurve, precurveTip=precurveTip)
 
-        CP, CT, CQ, dCP, dCT, dCQ \
-            = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=True)
+        outputs, derivs = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=True)
+        CP = outputs['CP']
+        CT = outputs['CT']
+        CQ = outputs['CQ']
+        dCP = derivs['dCP']
+        dCT = derivs['dCT']
+        dCQ = derivs['dCQ']
 
         dCT_dprecurveTip = dCT['dprecurveTip']
         dCQ_dprecurveTip = dCQ['dprecurveTip']
@@ -1433,7 +1595,10 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False, precurve=precurve, precurveTip=pct)
 
-        CPd, CTd, CQd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=True)
+        outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=True)
+        CPd = outputs['CP']
+        CTd = outputs['CT']
+        CQd = outputs['CQ']
 
         dCT_dprecurveTip_fd[:, 0] = (CTd - CT) / delta
         dCQ_dprecurveTip_fd[:, 0] = (CQd - CQ) / delta
@@ -1453,8 +1618,9 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=True, presweep=presweep, presweepTip=presweepTip)
 
-        Np, Tp, dNp, dTp \
-            = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Np = loads['Np']
+        Tp = loads['Tp']
 
         dNp_dpresweepTip_fd = np.zeros((self.n, 1))
         dTp_dpresweepTip_fd = np.zeros((self.n, 1))
@@ -1467,7 +1633,9 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False, presweep=presweep, presweepTip=pst)
 
-        Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Npd = loads['Np']
+        Tpd = loads['Tp']
         dNp_dpresweepTip_fd[:, 0] = (Npd - Np) / delta
         dTp_dpresweepTip_fd[:, 0] = (Tpd - Tp) / delta
 
@@ -1484,8 +1652,13 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=True, presweep=presweep, presweepTip=presweepTip)
 
-        P, T, Q, dP, dT, dQ \
-            = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=False)
+        outputs, derivs = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=False)
+        P = outputs['P']
+        T = outputs['T']
+        Q = outputs['Q']
+        dP = derivs['dP']
+        dT = derivs['dT']
+        dQ = derivs['dQ']
 
         dT_dpresweepTip = dT['dpresweepTip']
         dQ_dpresweepTip = dQ['dpresweepTip']
@@ -1503,7 +1676,10 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False, presweep=presweep, presweepTip=pst)
 
-        Pd, Td, Qd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=False)
+        outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=False)
+        Pd = outputs['P']
+        Td = outputs['T']
+        Qd = outputs['Q']
 
         dT_dpresweepTip_fd[:, 0] = (Td - T) / delta
         dQ_dpresweepTip_fd[:, 0] = (Qd - Q) / delta
@@ -1524,8 +1700,13 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=True, presweep=presweep, presweepTip=presweepTip)
 
-        CP, CT, CQ, dCP, dCT, dCQ \
-            = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=True)
+        outputs, derivs = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=True)
+        CP = outputs['CP']
+        CT = outputs['CT']
+        CQ = outputs['CQ']
+        dCP = derivs['dCP']
+        dCT = derivs['dCT']
+        dCQ = derivs['dCQ']
 
         dCT_dpresweepTip = dCT['dpresweepTip']
         dCQ_dpresweepTip = dCQ['dpresweepTip']
@@ -1543,7 +1724,10 @@ class TestGradients(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False, presweep=presweep, presweepTip=pst)
 
-        CPd, CTd, CQd = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficient=True)
+        outputs, _ = rotor.evaluate([self.Uinf], [self.Omega], [self.pitch], coefficients=True)
+        CPd = outputs['CP']
+        CTd = outputs['CT']
+        CQd = outputs['CQ']
 
         dCT_dpresweepTip_fd[:, 0] = (CTd - CT) / delta
         dCQ_dpresweepTip_fd[:, 0] = (CQd - CQ) / delta
@@ -1619,8 +1803,11 @@ class TestGradientsNotRotating(unittest.TestCase):
         self.azimuth = 90
 
 
-        self.Np, self.Tp, self.dNp, self.dTp \
-            = self.rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, derivs = self.rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        self.Np = loads['Np']
+        self.Tp = loads['Tp']
+        self.dNp = derivs['dNp']
+        self.dTp = derivs['dTp']
 
         self.rotor.derivatives = False
         self.n = len(self.r)
@@ -1643,7 +1830,9 @@ class TestGradientsNotRotating(unittest.TestCase):
                 self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
                 self.hubHt, self.nSector, derivatives=False)
 
-            Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+            loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+            Npd = loads['Np']
+            Tpd = loads['Tp']
 
             dNp_dr_fd[:, i] = (Npd - self.Np) / delta
             dTp_dr_fd[:, i] = (Tpd - self.Tp) / delta
@@ -1670,7 +1859,9 @@ class TestGradientsNotRotating(unittest.TestCase):
                 self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
                 self.hubHt, self.nSector, derivatives=False)
 
-            Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+            loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+            Npd = loads['Np']
+            Tpd = loads['Tp']
 
             dNp_dchord_fd[:, i] = (Npd - self.Np) / delta
             dTp_dchord_fd[:, i] = (Tpd - self.Tp) / delta
@@ -1696,7 +1887,9 @@ class TestGradientsNotRotating(unittest.TestCase):
                 self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
                 self.hubHt, self.nSector, derivatives=False)
 
-            Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+            loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+            Npd = loads['Np']
+            Tpd = loads['Tp']
 
             dNp_dtheta_fd[:, i] = (Npd - self.Np) / delta
             dTp_dtheta_fd[:, i] = (Tpd - self.Tp) / delta
@@ -1722,7 +1915,9 @@ class TestGradientsNotRotating(unittest.TestCase):
             self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False)
 
-        Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, _ = self.rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Npd = loads['Np']
+        Tpd = loads['Tp']
 
         dNp_dRhub_fd[:, 0] = (Npd - self.Np) / delta
         dTp_dRhub_fd[:, 0] = (Tpd - self.Tp) / delta
@@ -1747,7 +1942,10 @@ class TestGradientsNotRotating(unittest.TestCase):
             self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False)
 
-        Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Npd = loads['Np']
+        Tpd = loads['Tp']
+
         dNp_dRtip_fd[:, 0] = (Npd - self.Np) / delta
         dTp_dRtip_fd[:, 0] = (Tpd - self.Tp) / delta
 
@@ -1771,7 +1969,9 @@ class TestGradientsNotRotating(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False)
 
-        Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Npd = loads['Np']
+        Tpd = loads['Tp']
 
         dNp_dprecone_fd[:, 0] = (Npd - self.Np) / delta
         dTp_dprecone_fd[:, 0] = (Tpd - self.Tp) / delta
@@ -1796,7 +1996,9 @@ class TestGradientsNotRotating(unittest.TestCase):
             self.B, self.rho, self.mu, self.precone, tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False)
 
-        Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Npd = loads['Np']
+        Tpd = loads['Tp']
 
         dNp_dtilt_fd[:, 0] = (Npd - self.Np) / delta
         dTp_dtilt_fd[:, 0] = (Tpd - self.Tp) / delta
@@ -1821,7 +2023,9 @@ class TestGradientsNotRotating(unittest.TestCase):
             self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
             hubht, self.nSector, derivatives=False)
 
-        Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Npd = loads['Np']
+        Tpd = loads['Tp']
 
         dNp_dhubht_fd[:, 0] = (Npd - self.Np) / delta
         dTp_dhubht_fd[:, 0] = (Tpd - self.Tp) / delta
@@ -1846,7 +2050,9 @@ class TestGradientsNotRotating(unittest.TestCase):
             self.B, self.rho, self.mu, self.precone, self.tilt, yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False)
 
-        Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Npd = loads['Np']
+        Tpd = loads['Tp']
 
         dNp_dyaw_fd[:, 0] = (Npd - self.Np) / delta
         dTp_dyaw_fd[:, 0] = (Tpd - self.Tp) / delta
@@ -1872,7 +2078,9 @@ class TestGradientsNotRotating(unittest.TestCase):
             self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False)
 
-        Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, azimuth)
+        loads, _ = self.rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, azimuth)
+        Npd = loads['Np']
+        Tpd = loads['Tp']
 
         dNp_dazimuth_fd[:, 0] = (Npd - self.Np) / delta
         dTp_dazimuth_fd[:, 0] = (Tpd - self.Tp) / delta
@@ -1897,7 +2105,9 @@ class TestGradientsNotRotating(unittest.TestCase):
             self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False)
 
-        Npd, Tpd = rotor.distributedAeroLoads(Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, _ = self.rotor.distributedAeroLoads(Uinf, self.Omega, self.pitch, self.azimuth)
+        Npd = loads['Np']
+        Tpd = loads['Tp']
 
         dNp_dUinf_fd[:, 0] = (Npd - self.Np) / delta
         dTp_dUinf_fd[:, 0] = (Tpd - self.Tp) / delta
@@ -1927,7 +2137,9 @@ class TestGradientsNotRotating(unittest.TestCase):
             self.B, self.rho, self.mu, self.precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False)
 
-        Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, pitch, self.azimuth)
+        loads, _ = self.rotor.distributedAeroLoads(self.Uinf, self.Omega, pitch, self.azimuth)
+        Npd = loads['Np']
+        Tpd = loads['Tp']
 
         dNp_dpitch_fd[:, 0] = (Npd - self.Np) / delta
         dTp_dpitch_fd[:, 0] = (Tpd - self.Tp) / delta
@@ -1946,9 +2158,11 @@ class TestGradientsNotRotating(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=True, precurve=precurve, precurveTip=precurveTip)
 
-        Np, Tp, dNp, dTp \
-            = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
-
+        loads, derivs = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Np = loads['Np']
+        Tp = loads['Tp']
+        dNp = derivs['dNp']
+        dTp = derivs['dTp']
 
         dNp_dprecurve = dNp['dprecurve']
         dTp_dprecurve = dTp['dprecurve']
@@ -1964,7 +2178,9 @@ class TestGradientsNotRotating(unittest.TestCase):
                 self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
                 self.hubHt, self.nSector, derivatives=False, precurve=pc, precurveTip=precurveTip)
 
-            Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+            loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+            Npd = loads['Np']
+            Tpd = loads['Tp']
 
             dNp_dprecurve_fd[:, i] = (Npd - Np) / delta
             dTp_dprecurve_fd[:, i] = (Tpd - Tp) / delta
@@ -1981,8 +2197,11 @@ class TestGradientsNotRotating(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=True, presweep=presweep, presweepTip=presweepTip)
 
-        Np, Tp, dNp, dTp \
-            = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, derivs = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Np = loads['Np']
+        Tp = loads['Tp']
+        dNp = derivs['dNp']
+        dTp = derivs['dTp']
 
         dNp_dpresweep = dNp['dpresweep']
         dTp_dpresweep = dTp['dpresweep']
@@ -1998,7 +2217,9 @@ class TestGradientsNotRotating(unittest.TestCase):
                 self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
                 self.hubHt, self.nSector, derivatives=False, presweep=ps, presweepTip=presweepTip)
 
-            Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+            loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+            Npd = loads['Np']
+            Tpd = loads['Tp']
 
             dNp_dpresweep_fd[:, i] = (Npd - Np) / delta
             dTp_dpresweep_fd[:, i] = (Tpd - Tp) / delta
@@ -2016,8 +2237,11 @@ class TestGradientsNotRotating(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=True, precurve=precurve, precurveTip=precurveTip)
 
-        Np, Tp, dNp, dTp \
-            = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, derivs = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Np = loads['Np']
+        Tp = loads['Tp']
+        dNp = derivs['dNp']
+        dTp = derivs['dTp']
 
         dNp_dprecurveTip_fd = np.zeros((self.n, 1))
         dTp_dprecurveTip_fd = np.zeros((self.n, 1))
@@ -2030,7 +2254,9 @@ class TestGradientsNotRotating(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False, precurve=precurve, precurveTip=pct)
 
-        Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Npd = loads['Np']
+        Tpd = loads['Tp']
         dNp_dprecurveTip_fd[:, 0] = (Npd - Np) / delta
         dTp_dprecurveTip_fd[:, 0] = (Tpd - Tp) / delta
 
@@ -2047,8 +2273,11 @@ class TestGradientsNotRotating(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=True, presweep=presweep, presweepTip=presweepTip)
 
-        Np, Tp, dNp, dTp \
-            = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, derivs = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Np = loads['Np']
+        Tp = loads['Tp']
+        dNp = derivs['dNp']
+        dTp = derivs['dTp']
 
         dNp_dpresweepTip_fd = np.zeros((self.n, 1))
         dTp_dpresweepTip_fd = np.zeros((self.n, 1))
@@ -2061,7 +2290,9 @@ class TestGradientsNotRotating(unittest.TestCase):
             self.B, self.rho, self.mu, precone, self.tilt, self.yaw, self.shearExp,
             self.hubHt, self.nSector, derivatives=False, presweep=presweep, presweepTip=pst)
 
-        Npd, Tpd = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        loads, _ = rotor.distributedAeroLoads(self.Uinf, self.Omega, self.pitch, self.azimuth)
+        Npd = loads['Np']
+        Tpd = loads['Tp']
         dNp_dpresweepTip_fd[:, 0] = (Npd - Np) / delta
         dTp_dpresweepTip_fd[:, 0] = (Tpd - Tp) / delta
 
@@ -2131,11 +2362,13 @@ class TestGradientsFreestreamArray(unittest.TestCase):
         self.pitch = np.zeros(3)
         self.Omega = self.Uinf*tsr/self.Rtip * 30.0/pi  # convert to RPM
 
-        self.P, self.T, self.Q, self.dP, self.dT, self.dQ \
-            = self.rotor.evaluate(self.Uinf, self.Omega, self.pitch, coefficient=False)
+        outputs, derivs = self.rotor.evaluate(self.Uinf, self.Omega, self.pitch, coefficients=False)
+        self.P, self.T, self.Q = [outputs[k] for k in ('P', 'T', 'Q')]
+        self.dP, self.dT, self.dQ = [derivs[k] for k in ('dP', 'dT', 'dQ')]
 
-        self.CP, self.CT, self.CQ, self.dCP, self.dCT, self.dCQ \
-            = self.rotor.evaluate(self.Uinf, self.Omega, self.pitch, coefficient=True)
+        outputs, derivs = self.rotor.evaluate(self.Uinf, self.Omega, self.pitch, coefficients=True)
+        self.CP, self.CT, self.CQ = [outputs[k] for k in ('CP', 'CT', 'CQ')]
+        self.dCP, self.dCT, self.dCQ = [derivs[k] for k in ('dCP', 'dCT', 'dCQ')]
 
         self.rotor.derivatives = False
         self.n = len(self.r)
@@ -2158,7 +2391,10 @@ class TestGradientsFreestreamArray(unittest.TestCase):
             delta = 1e-6*Uinf[i]
             Uinf[i] += delta
 
-            Pd, Td, Qd = self.rotor.evaluate(Uinf, self.Omega, self.pitch, coefficient=False)
+            outputs, _ = self.rotor.evaluate(Uinf, self.Omega, self.pitch, coefficients=False)
+            Pd = outputs['P']
+            Td = outputs['T']
+            Qd = outputs['Q']
 
             dT_dUinf_fd[:, i] = (Td - self.T) / delta
             dQ_dUinf_fd[:, i] = (Qd - self.Q) / delta
@@ -2185,7 +2421,10 @@ class TestGradientsFreestreamArray(unittest.TestCase):
             delta = 1e-6*Uinf[i]
             Uinf[i] += delta
 
-            CPd, CTd, CQd = self.rotor.evaluate(Uinf, self.Omega, self.pitch, coefficient=True)
+            outputs, _ = self.rotor.evaluate(Uinf, self.Omega, self.pitch, coefficients=True)
+            CPd = outputs['CP']
+            CTd = outputs['CT']
+            CQd = outputs['CQ']
 
             dCT_dUinf_fd[:, i] = (CTd - self.CT) / delta
             dCQ_dUinf_fd[:, i] = (CQd - self.CQ) / delta
@@ -2211,7 +2450,10 @@ class TestGradientsFreestreamArray(unittest.TestCase):
             delta = 1e-6*Omega[i]
             Omega[i] += delta
 
-            Pd, Td, Qd = self.rotor.evaluate(self.Uinf, Omega, self.pitch, coefficient=False)
+            outputs, _ = self.rotor.evaluate(self.Uinf, Omega, self.pitch, coefficients=False)
+            Pd = outputs['P']
+            Td = outputs['T']
+            Qd = outputs['Q']
 
             dT_dOmega_fd[:, i] = (Td - self.T) / delta
             dQ_dOmega_fd[:, i] = (Qd - self.Q) / delta
@@ -2238,7 +2480,10 @@ class TestGradientsFreestreamArray(unittest.TestCase):
             delta = 1e-6*Omega[i]
             Omega[i] += delta
 
-            CPd, CTd, CQd = self.rotor.evaluate(self.Uinf, Omega, self.pitch, coefficient=True)
+            outputs, _ = self.rotor.evaluate(self.Uinf, Omega, self.pitch, coefficients=True)
+            CPd = outputs['CP']
+            CTd = outputs['CT']
+            CQd = outputs['CQ']
 
             dCT_dOmega_fd[:, i] = (CTd - self.CT) / delta
             dCQ_dOmega_fd[:, i] = (CQd - self.CQ) / delta
@@ -2264,7 +2509,10 @@ class TestGradientsFreestreamArray(unittest.TestCase):
             delta = 1e-6
             pitch[i] += delta
 
-            Pd, Td, Qd = self.rotor.evaluate(self.Uinf, self.Omega, pitch, coefficient=False)
+            outputs, _ = self.rotor.evaluate(self.Uinf, self.Omega, pitch, coefficients=False)
+            Pd = outputs['P']
+            Td = outputs['T']
+            Qd = outputs['Q']
 
             dT_dpitch_fd[:, i] = (Td - self.T) / delta
             dQ_dpitch_fd[:, i] = (Qd - self.Q) / delta
@@ -2291,7 +2539,10 @@ class TestGradientsFreestreamArray(unittest.TestCase):
             delta = 1e-6
             pitch[i] += delta
 
-            CPd, CTd, CQd = self.rotor.evaluate(self.Uinf, self.Omega, pitch, coefficient=True)
+            outputs, _ = self.rotor.evaluate(self.Uinf, self.Omega, pitch, coefficients=True)
+            CPd = outputs['CP']
+            CTd = outputs['CT']
+            CQd = outputs['CQ']
 
             dCT_dpitch_fd[:, i] = (CTd - self.CT) / delta
             dCQ_dpitch_fd[:, i] = (CQd - self.CQ) / delta


### PR DESCRIPTION
This refactors `CCBlade.distributedAeroLoads()` and `CCBlade.evaluate()` to return dicts for outputs and derivatives instead of tuples. This provides a more unified interface for these methods regardless of the values of the `induction` and `derivatives` flags.
It makes it much easer to add additional outputs at the blade and rotor levels, and some additional outputs - `W`, `Re` and perhaps a few other I can't remember - are added.

This PR also does away with some of the confusing logic which returned variable-length tuples based on their values of `CCBlade.induction` and `CCBlade.derivatives`. Now, those flag still exist, but their values only determine if values actually get put into the output dicts. As before, no derivatives are computed if `CCBlade.derivatives` is `False`

This also fixes all tests, addressing #15 